### PR TITLE
Print scan results in kubectl output and webhook logs

### DIFF
--- a/pkg/webhook/daemonset.go
+++ b/pkg/webhook/daemonset.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
+	"encoding/json"
 )
 
 // daemonSetsValidator validates the definition against the Kubesec.io score.
@@ -58,10 +59,17 @@ func (d *daemonSetsValidator) Validate(_ context.Context, obj metav1.Object) (bo
 		return false, validating.ValidatorResult{Valid: true}, nil
 	}
 
+	jq, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+	    d.logger.Errorf("kubesec.io pretty printing issue %v", err)
+	    return false, validating.ValidatorResult{Valid: true}, nil
+	}
+	d.logger.Infof("Scan Result:\n%s", jq)
+
 	if result.Score < d.minScore {
 		return true, validating.ValidatorResult{
 			Valid:   false,
-			Message: fmt.Sprintf("%s score is %d, daemonset minimum accepted score is %d", kObj.Name, result.Score, d.minScore),
+			Message: fmt.Sprintf("%s score is %d, daemonset minimum accepted score is %d\nScan Result:\n%s", kObj.Name, result.Score, d.minScore, jq),
 		}, nil
 	}
 

--- a/pkg/webhook/deployment.go
+++ b/pkg/webhook/deployment.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
+	"encoding/json"
 )
 
 // deploymentValidator validates the definition against the Kubesec.io score.
@@ -57,10 +58,17 @@ func (d *deploymentValidator) Validate(_ context.Context, obj metav1.Object) (bo
 		return false, validating.ValidatorResult{Valid: true}, nil
 	}
 
+	jq, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+	    d.logger.Errorf("kubesec.io pretty printing issue %v", err)
+	    return false, validating.ValidatorResult{Valid: true}, nil
+	}
+	d.logger.Infof("Scan Result:\n%s", jq)
+
 	if result.Score < d.minScore {
 		return true, validating.ValidatorResult{
 			Valid:   false,
-			Message: fmt.Sprintf("%s score is %d, deployment minimum accepted score is %d", kObj.Name, result.Score, d.minScore),
+			Message: fmt.Sprintf("%s score is %d, deployment minimum accepted score is %d\nScan Result:\n%s", kObj.Name, result.Score, d.minScore, jq),
 		}, nil
 	}
 

--- a/pkg/webhook/statefulset.go
+++ b/pkg/webhook/statefulset.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
+	"encoding/json"
 )
 
 // statefulSetValidator validates the definition against the Kubesec.io score.
@@ -58,10 +59,17 @@ func (d *statefulSetValidator) Validate(_ context.Context, obj metav1.Object) (b
 		return false, validating.ValidatorResult{Valid: true}, nil
 	}
 
+	jq, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+	    d.logger.Errorf("kubesec.io pretty printing issue %v", err)
+	    return false, validating.ValidatorResult{Valid: true}, nil
+	}
+	d.logger.Infof("Scan Result:\n%s", jq)
+
 	if result.Score < d.minScore {
 		return true, validating.ValidatorResult{
 			Valid:   false,
-			Message: fmt.Sprintf("%s score is %d, statefulset minimum accepted score is %d", kObj.Name, result.Score, d.minScore),
+			Message: fmt.Sprintf("%s score is %d, statefulset minimum accepted score is %d\nScan Result:\n%s", kObj.Name, result.Score, d.minScore, jq),
 		}, nil
 	}
 


### PR DESCRIPTION
#3 
## Unit Test
**kubectl output**
```
$ kubectl apply -f ./test/ -n pd-test
pod/pod-test unchanged
Error from server (InternalError): error when creating "test/daemonset.yaml": Internal error occurred: admission webhook "daemonset.admission.kubesc.io" denied the request: daemonset-test score is -30, daemonset minimum accepted score is 0
Scan Result:
{
  "error": "",
  "score": -30,
  "scoring": {
    "critical": [
      {
        "selector": "containers[] .securityContext .privileged == true",
        "reason": "Privileged containers can allow almost completely unrestricted host access",
        "weight": 0
      }
    ],
    "advise": [
      {
        "selector": "containers[] .securityContext .runAsNonRoot == true",
        "reason": "Force the running image to run as a non-root user to ensure least privilege"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop",
        "reason": "Reducing kernel capabilities available to a container limits its attack surface",
        "href": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
      },
      {
        "selector": "containers[] .securityContext .readOnlyRootFilesystem == true",
        "reason": "An immutable root filesystem can prevent malicious binaries being added to PATH and increase attack cost"
      },
      {
        "selector": "containers[] .securityContext .runAsUser \u003e 10000",
        "reason": "Run as a high-UID user to avoid conflicts with the host's user table"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop | index(\"ALL\")",
        "reason": "Drop all capabilities and add only those required to reduce syscall attack surface"
      }
    ]
  }
}
Error from server (InternalError): error when creating "test/deployment.yaml": Internal error occurred: admission webhook "deployment.admission.kubesc.io" denied the request: deployment-test score is -30, deployment minimum accepted score is 0
Scan Result:
{
  "error": "",
  "score": -30,
  "scoring": {
    "critical": [
      {
        "selector": "containers[] .securityContext .privileged == true",
        "reason": "Privileged containers can allow almost completely unrestricted host access",
        "weight": 0
      }
    ],
    "advise": [
      {
        "selector": "containers[] .securityContext .runAsNonRoot == true",
        "reason": "Force the running image to run as a non-root user to ensure least privilege"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop",
        "reason": "Reducing kernel capabilities available to a container limits its attack surface",
        "href": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
      },
      {
        "selector": "containers[] .securityContext .readOnlyRootFilesystem == true",
        "reason": "An immutable root filesystem can prevent malicious binaries being added to PATH and increase attack cost"
      },
      {
        "selector": "containers[] .securityContext .runAsUser \u003e 10000",
        "reason": "Run as a high-UID user to avoid conflicts with the host's user table"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop | index(\"ALL\")",
        "reason": "Drop all capabilities and add only those required to reduce syscall attack surface"
      }
    ]
  }
}
Error from server (InternalError): error when creating "test/statefulset.yaml": Internal error occurred: admission webhook "statefulset.admission.kubesc.io" denied the request: statefulset-test score is -30, statefulset minimum accepted score is 0
Scan Result:
{
  "error": "",
  "score": -30,
  "scoring": {
    "critical": [
      {
        "selector": "containers[] .securityContext .privileged == true",
        "reason": "Privileged containers can allow almost completely unrestricted host access",
        "weight": 0
      }
    ],
    "advise": [
      {
        "selector": ".spec .volumeClaimTemplates[] .spec .accessModes | index(\"ReadWriteOnce\")",
        "reason": ""
      },
      {
        "selector": "containers[] .securityContext .runAsNonRoot == true",
        "reason": "Force the running image to run as a non-root user to ensure least privilege"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop",
        "reason": "Reducing kernel capabilities available to a container limits its attack surface",
        "href": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
      },
      {
        "selector": "containers[] .securityContext .readOnlyRootFilesystem == true",
        "reason": "An immutable root filesystem can prevent malicious binaries being added to PATH and increase attack cost"
      },
      {
        "selector": "containers[] .securityContext .runAsUser \u003e 10000",
        "reason": "Run as a high-UID user to avoid conflicts with the host's user table"
      }
    ]
  }
}
```
**Webhook logs**
```
$ kubectl logs kubesec-webhook-576994f77f-tdctq -n kubesec -f
2019/09/12 02:40:13 [INFO] webhooks listening on :8080...
2019/09/12 02:40:13 [INFO] metrics listening on :8081...
2019/09/12 02:40:43 [DEBUG] reviewing request b75695a4-d506-11e9-9336-f213d8fe6e28, named: pd-test/
2019/09/12 02:40:43 [INFO] Scanning daemonset daemonset-test
2019/09/12 02:40:45 [INFO] Scan Result:
{
  "error": "",
  "score": -30,
  "scoring": {
    "critical": [
      {
        "selector": "containers[] .securityContext .privileged == true",
        "reason": "Privileged containers can allow almost completely unrestricted host access",
        "weight": 0
      }
    ],
    "advise": [
      {
        "selector": "containers[] .securityContext .runAsNonRoot == true",
        "reason": "Force the running image to run as a non-root user to ensure least privilege"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop",
        "reason": "Reducing kernel capabilities available to a container limits its attack surface",
        "href": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
      },
      {
        "selector": "containers[] .securityContext .readOnlyRootFilesystem == true",
        "reason": "An immutable root filesystem can prevent malicious binaries being added to PATH and increase attack cost"
      },
      {
        "selector": "containers[] .securityContext .runAsUser \u003e 10000",
        "reason": "Run as a high-UID user to avoid conflicts with the host's user table"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop | index(\"ALL\")",
        "reason": "Drop all capabilities and add only those required to reduce syscall attack surface"
      }
    ]
  }
}
2019/09/12 02:40:45 [DEBUG] reviewing request b8a883a5-d506-11e9-9336-f213d8fe6e28, named: pd-test/
2019/09/12 02:40:45 [INFO] Scanning deployment deployment-test
2019/09/12 02:40:46 [INFO] Scan Result:
{
  "error": "",
  "score": -30,
  "scoring": {
    "critical": [
      {
        "selector": "containers[] .securityContext .privileged == true",
        "reason": "Privileged containers can allow almost completely unrestricted host access",
        "weight": 0
      }
    ],
    "advise": [
      {
        "selector": "containers[] .securityContext .runAsNonRoot == true",
        "reason": "Force the running image to run as a non-root user to ensure least privilege"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop",
        "reason": "Reducing kernel capabilities available to a container limits its attack surface",
        "href": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
      },
      {
        "selector": "containers[] .securityContext .readOnlyRootFilesystem == true",
        "reason": "An immutable root filesystem can prevent malicious binaries being added to PATH and increase attack cost"
      },
      {
        "selector": "containers[] .securityContext .runAsUser \u003e 10000",
        "reason": "Run as a high-UID user to avoid conflicts with the host's user table"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop | index(\"ALL\")",
        "reason": "Drop all capabilities and add only those required to reduce syscall attack surface"
      }
    ]
  }
}
2019/09/12 02:40:47 [DEBUG] reviewing request b9a3b269-d506-11e9-9336-f213d8fe6e28, named: pd-test/
2019/09/12 02:40:47 [INFO] Scanning statefulset statefulset-test
2019/09/12 02:40:48 [INFO] Scan Result:
{
  "error": "",
  "score": -30,
  "scoring": {
    "critical": [
      {
        "selector": "containers[] .securityContext .privileged == true",
        "reason": "Privileged containers can allow almost completely unrestricted host access",
        "weight": 0
      }
    ],
    "advise": [
      {
        "selector": ".spec .volumeClaimTemplates[] .spec .accessModes | index(\"ReadWriteOnce\")",
        "reason": ""
      },
      {
        "selector": "containers[] .securityContext .runAsNonRoot == true",
        "reason": "Force the running image to run as a non-root user to ensure least privilege"
      },
      {
        "selector": "containers[] .securityContext .capabilities .drop",
        "reason": "Reducing kernel capabilities available to a container limits its attack surface",
        "href": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
      },
      {
        "selector": "containers[] .securityContext .readOnlyRootFilesystem == true",
        "reason": "An immutable root filesystem can prevent malicious binaries being added to PATH and increase attack cost"
      },
      {
        "selector": "containers[] .securityContext .runAsUser \u003e 10000",
        "reason": "Run as a high-UID user to avoid conflicts with the host's user table"
      }
    ]
  }
}
```