### PR TITLE
Update webhook.yaml api-version for kube 1.16

### DIFF
--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubesec-webhook


### PR DESCRIPTION
Kubenetes 1.16 deprecated a few api versions. This is just a quick fix for the webhook deployment to allow it to be applied to post-1.16 clusters.