### PR TITLE
Add match label selector required by new api version

### DIFF
--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -7,6 +7,9 @@ metadata:
     app: kubesec-webhook
   namespace: kubesec
 spec:
+  selector:
+    matchLabels:
+      app: kubesec-webhook
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Fixing an oversight from my previous PR. The new api version requires a selector matchLabel for the deployment so that's been added.