### PR TITLE
feat: use docker to generate certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Temporary folder for creating certs
+deploy/certs

--- a/deploy/gen-certs.sh
+++ b/deploy/gen-certs.sh
@@ -3,25 +3,43 @@
 # Defaults
 NAMESPACE=${1:-"kubesec"}
 NAME=${2:-"kubesec-webhook"}
-OS="`uname`"
+OS="$(uname)"
 
 # Generate cert
-openssl genrsa -out webhookCA.key 2048
-openssl req -new -key ./webhookCA.key -subj "/CN=${NAME}.${NAMESPACE}.svc" -out ./webhookCA.csr
-openssl x509 -req -days 365 -in webhookCA.csr -signkey webhookCA.key -out webhook.crt
+
+subj="/CN=${NAME}.${NAMESPACE}.svc"
+addext="subjectAltName=DNS:${NAME}.${NAMESPACE}.svc"
+
+mkdir -p ./certs
+
+echo "$addext" >> ./certs/kubesec.cnf
+echo extendedKeyUsage = serverAuth >> ./certs/kubesec.cnf
+
+docker run --rm -v "${PWD}/certs/":/certs/ --user "$(id -u):$(id -g)" alpine/openssl genrsa -out /certs/webhookCA.key 2048
+docker run --rm -v "${PWD}/certs/":/certs/ --user "$(id -u):$(id -g)" alpine/openssl req -new -key /certs/webhookCA.key \
+  -subj "$subj" \
+  -addext "$addext" \
+  -out /certs/webhookCA.csr
+
+docker run --rm -v "${PWD}/certs/":/certs/ --user "$(id -u):$(id -g)" alpine/openssl x509 -req \
+  -extfile /certs/kubesec.cnf \
+  -days 365 \
+  -in /certs/webhookCA.csr \
+  -signkey /certs/webhookCA.key \
+  -out /certs/webhook.crt
 
 # Generate cert secret
 kubectl -n kubesec create secret generic \
-    ${NAME}-certs \
-    --from-file=key.pem=./webhookCA.key \
-    --from-file=cert.pem=./webhook.crt \
-    --dry-run -o yaml > ./webhook-certs.yaml
+    "${NAME}"-certs \
+    --from-file=key.pem=./certs/webhookCA.key \
+    --from-file=cert.pem=./certs/webhook.crt \
+    --dry-run=client -o yaml > ./webhook-certs.yaml
 
 # Encode CABundle
 if [[ "$OS" == "Darwin" ]]; then
-    CA_BUNDLE=$(cat ./webhook.crt | base64)
+    CA_BUNDLE=$(cat ./certs/webhook.crt | base64)
 elif [[ "$OS" == "Linux" ]]; then
-    CA_BUNDLE=$(cat ./webhook.crt | base64 -w0)
+    CA_BUNDLE=$(cat ./certs/webhook.crt | base64 -w0)
 else
     echo "Unsupported OS ${OS}"
     exit 1
@@ -31,4 +49,4 @@ fi
 sed "s/CA_BUNDLE/${CA_BUNDLE}/" ./webhook-registration.yaml.tpl > ./webhook-registration.yaml
 
 # Clean
-rm ./webhookCA* && rm ./webhook.crt
+rm -rf ./certs/


### PR DESCRIPTION
- closes controlplaneio#15
- webhook failing in k8s 1.19
- issue with GoLang 1.15: x509: certificate relies on legacy Common Name field, use SANs
- set subjectAltName in x509 cert
- tested in latest releases of k8s 1.16 to 1.19
- kubectl --dry-run is deprecated and can be replaced with --dry-run=client
- using docker to create certificate to remove openssl 1.1.1 dependency