### PR TITLE
feat: add Github Actions workflows

### DIFF
--- a/.github/workflows/lint_go.yml
+++ b/.github/workflows/lint_go.yml
@@ -1,0 +1,28 @@
+---
+name: Linting - Go
+# Split until path filtering for jobs added
+# https://github.community/t/path-filtering-for-jobs-and-steps/16447
+on:
+  push:
+    branches: [master]
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+  pull_request:
+    branches: [master]
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run golangci-lint
+        uses: reviewdog/action-golangci-lint@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+---
+name: Release
+on:
+  # https://github.com/actions/runner/issues/1007
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release:
+    name: Release on GitHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/release_containers.yml
+++ b/.github/workflows/release_containers.yml
@@ -1,0 +1,80 @@
+---
+name: Release Containers
+on:
+  # https://github.com/actions/runner/issues/1007
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release-containers:
+    name: Build and Push container - ${{ matrix.containers.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        containers:
+          - name: kubesec-webhook
+            file: ./Dockerfile
+            suffix: ""
+
+    steps:
+      - name: Cache container layers
+        uses: actions/cache@v3.3.2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}${{ matrix.containers.suffix }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}${{ matrix.containers.suffix }}-buildx-
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate container tags and labels
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: kubesec/kubesec-webhook
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}
+          flavor: |
+            latest=${{ matrix.containers.suffix == '' }}
+            suffix=${{ matrix.containers.suffix }}
+          labels: |
+            org.opencontainers.image.vendor=controlplane
+            org.opencontainers.image.url=https://kubesec.io/
+
+      - name: Login to Docker Hub Registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@v3.0.0
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.repository_owner }}
+      #     password: ${{ secrets.CR_PAT }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build container and push tags
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          file: ${{ matrix.containers.file }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: mode=max,type=local,dest=/tmp/.buildx-cache
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            COMMIT=${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.revision'] }}

--- a/.github/workflows/security_analysis.yml
+++ b/.github/workflows/security_analysis.yml
@@ -1,0 +1,39 @@
+---
+name: Security Analysis
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: go
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Vulnerability Scan Go Code
+        uses: Templum/govulncheck-action@v1.0.0
+        with:
+           go-version: 1.20.6
+           vulncheck-version: v1.0.0


### PR DESCRIPTION
This PR addresses https://github.com/controlplaneio/kubesec-webhook/issues/27 by adding the following GitHub Actions workflows to the repo:

- Linting - Go
- Release Containers
- Release
- Security Analysis

Docker Hub creds are required to push to the `kubesec/kubesec-webhook` repository.